### PR TITLE
Allow usage of Elevation in scripts by factoring out Elevation.get_elevation

### DIFF
--- a/Elevation.py
+++ b/Elevation.py
@@ -95,6 +95,9 @@ class Elevation:
 			QMessageBox.warning(self.iface.mainWindow(), 'Elevation', 'JSON decode failed: '+str(jsonresult), QMessageBox.Ok, QMessageBox.Ok)
 
 	def obtain_action(self, point) :
+		epsg4326 = QgsCoordinateReferenceSystem(4326, QgsCoordinateReferenceSystem.EpsgCrsId)
+		self.reprojectgeographic = QgsCoordinateTransform(self.iface.mapCanvas().mapRenderer().destinationCrs(), epsg4326)
+		pt = self.reprojectgeographic.transform(point)
 		elevation = self.get_elevation(point)
 		if elevation == None:
 			QMessageBox.warning(self.iface.mainWindow(), 'Elevation', 'Failed to get elevation.', QMessageBox.Ok, QMessageBox.Ok)

--- a/README.md
+++ b/README.md
@@ -18,3 +18,16 @@ The installation can be installed by selecting Plugins->Manage and Install Plugi
 followed by a click on "Get more".
 
 Installation from the source tarball is also possible.
+
+Usage in python scripts
+=======================
+
+You can also get the elevation from python scripts. 
+
+```
+from elevation.Elevation import Elevation #import the plugin
+elev = Elevation(iface) #initialise the plugin
+ext = iface.mapCanvas().extent() #get the current map canvas extent
+point = QgsPoint(ext.xMinimum(),ext.yMinimum()) #make a point for the bottom left corner
+elev.get_elevation(point) #get the elevation for the point
+```

--- a/__init__.py
+++ b/__init__.py
@@ -28,7 +28,7 @@ def name():
 def description():
 	return "Obtain and display point elevation data using Google Maps"
 def version(): 
-	return "Version 0.4.0" 
+	return "Version 0.5.0" 
 def qgisMinimumVersion():
 	return "2.0"
 def classFactory(iface): 


### PR DESCRIPTION
I needed to be able to get the elevation of a point from a script so I added something to the Elevation plugin. It now has a get_elevation method which can be used from any code to get the elevation. I factored this code out of obtain_action.

In the README.md I have added docs for the usage of the plugin from other scripts (or the python console).

I hope this addition is useful.
